### PR TITLE
Fix kwarg instead of optional positional arg.

### DIFF
--- a/src/parser.jl
+++ b/src/parser.jl
@@ -2195,7 +2195,7 @@ end
 # Parser Entry Method
 #========================#
 
-function parse(ts::TokenStream, production = parse_stmts)
+function parse(ts::TokenStream; production = parse_stmts)
     Lexer.skipws_and_comments(ts)
     t = Lexer.peek_token(ts, false)
     while true


### PR DESCRIPTION
This fixes:

* https://travis-ci.org/JuliaLang/JuliaParser.jl#L287

`ERROR: LoadError: LoadError: function parse does not accept keyword arguments`