### PR TITLE
enable precompilation

### DIFF
--- a/src/JuliaParser.jl
+++ b/src/JuliaParser.jl
@@ -1,4 +1,5 @@
-#__precompile__()
+__precompile__()
+
 module JuliaParser
 
 export Parser, Lexer


### PR DESCRIPTION
Commented out in https://github.com/JuliaLang/JuliaParser.jl/commit/61ed9a5e6cb206179febd36a59d574e743877857. 

Seems like this package should be fine to precompile so was it just a mistake to comment it out @Keno?
