### PR TITLE
Report the correct column number for diagnostic printing with unicode

### DIFF
--- a/bin/repl.jl
+++ b/bin/repl.jl
@@ -8,6 +8,7 @@ if ccall(:jl_generating_output, Cint, ()) == 0
     ORIG_STDERR = STDERR
     redirect_stderr()
 end
+
 immutable REPLDiagnostic
     fname::AbstractString
     text::AbstractString
@@ -20,10 +21,12 @@ function Base.showerror(io::IO, d::REPLDiagnostic, bt)
     print_with_color(:white,io,"")
     JuliaParser.Diagnostics.display_diagnostic(io, d.text, extract_diag(d.d); filename = d.fname)
 end
+
 function Base.showerror(io::IO, d::REPLDiagnostic)
     print_with_color(:white,io,"")
     JuliaParser.Diagnostics.display_diagnostic(io, d.text, extract_diag(d.d); filename = d.fname)
 end
+
 function Base.REPL.display_error(io::IO, d::REPLDiagnostic, bt)
     print_with_color(:white,io,"")
     JuliaParser.Diagnostics.display_diagnostic(io, d.text, extract_diag(d.d); filename = d.fname)
@@ -124,8 +127,10 @@ function Base.incomplete_tag(e::Expr)
     isa(e.args[1].d, Main.JuliaParser.Diagnostics.Incomplete) || return :none
     e.args[1].d.tag
 end
+
 if ccall(:jl_generating_output, Cint, ()) == 0
     REDIRECTED_STDERR = STDERR
     redirect_stderr(ORIG_STDERR)
 end
+
 end

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -11,6 +11,7 @@ module Diagnostics
         location::SourceRange
         text::AbstractString
     end
+
     immutable Diagnostic <: AbstractDiagnostic
         elements::Vector{Message}
     end
@@ -19,7 +20,6 @@ module Diagnostics
         tag::Symbol
         d::Diagnostic
     end
-
 
     function after(loc)
         loc = normalize_loc(loc)

--- a/src/diagnostics.jl
+++ b/src/diagnostics.jl
@@ -33,7 +33,7 @@ module Diagnostics
         SourceRange(loc.offset-1,1,loc.file)
     end
 
-    function normalize_loc(loc)    
+    function normalize_loc(loc)
         isa(loc, SourceNode) && (loc = loc.loc)
         isa(loc, Union{SourceExpr, SourceLocToken}) && (loc = √loc)
         isa(loc, Token) && (loc = SourceRange())
@@ -66,7 +66,8 @@ module Diagnostics
             end
             offset = message.location.offset
             line = compute_line(file, offset)
-            col = offset - file.offsets[line] + 1
+            str  = String(file[line])
+            col  = sum(charwidth, str[1:(offset - file.offsets[line] + 1)])
             if message.severity == :fixit
                 print(io, " "^(col-1))
                 print_with_color(:green, io, message.text)
@@ -75,12 +76,11 @@ module Diagnostics
                 print(io, "$filename:$line:$col " )
                 print_with_color(message.severity == :error ? :red : :magenta, io, string(message.severity))
                 println(io, ": ", message.text)
-                println(io, rstrip(String(file[line])))
+                println(io, rstrip(str))
                 print(io, " "^(col-1))
                 print_with_color(:green, io, string('^',"~"^(max(0,message.location.length-1))))
                 println(io)
             end
         end
     end
-
 end

--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -452,3 +452,24 @@ let diags = do_diag_test("ccall((:SetVarDeclInit, libcxxffi), Void, (Ptr{Void},)
     @test diags.elements[1].location.offset == 55
     @test diags.elements[2].severity == :note
 end
+
+# fix issue #47
+
+# test string with charwidth < 1
+let code = "(foo̧ + b̂ar))",
+    diag = do_diag_test(code)
+
+    io = IOBuffer()
+    JuliaParser.Diagnostics.display_diagnostic(io, code, diag, filename="test")
+    res = takebuf_string(io)
+    @test startswith(res, "test:1:12")
+end
+
+# test string with charwidth > 1
+let code = "(foo̧ + 🔨))",
+    diag = do_diag_test(code)
+    io = IOBuffer()
+    JuliaParser.Diagnostics.display_diagnostic(io, code, diag, filename="test")
+    res = takebuf_string(io)
+    @test startswith(res, "test:1:11")
+end


### PR DESCRIPTION
```julia
julia> (foo̧ + 🔨))
REPL:1:11 error: extra token ")" after end of expression
(foo̧ + 🔨))
          ^


julia> (foo̧ + b̂ar))
REPL:1:12 error: extra token ")" after end of expression
(foo̧ + b̂ar))
           ^
```
Fixes #47 

