### PR TITLE
Small typo: Base.include_string

### DIFF
--- a/bin/repl.jl
+++ b/bin/repl.jl
@@ -50,7 +50,7 @@ function Core.include(fname::String)
     result
 end
 
-function Base.include_string(code, filename = string)
+function Base.include_string(code, filename = "string")
     ts = Lexer.TokenStream{Lexer.SourceLocToken}(code)
     ts.filename = filename
     local result = nothing


### PR DESCRIPTION
"string" rather than string: Base.include_string(code, filename = "string") (which matches the original behavior)
