### PR TITLE
remove use of is()

### DIFF
--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -328,7 +328,7 @@ end
 
 eof(io::IO) = Base.eof(io)
 eof(t::AbstractToken) = eof(¬t)
-eof(c) = is(c, EOF_CHAR)
+eof(c) = c===EOF_CHAR
 
 readchar(io::IO) = eof(io) ? EOF_CHAR : read(io, Char)
 takechar(io::IO) = (readchar(io); io)

--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -317,7 +317,7 @@ function peekchar(io::IOBuffer)
 end
 
 # this implementation is copied from Base
-const _CHTMP = Array{Char} (1)
+const _CHTMP = Array{Char}(1)
 
 peekchar(s::IOStream) = begin
     if ccall(:ios_peekutf8, Int32, (Ptr{Void}, Ptr{Char}), s, _CHTMP) < 0

--- a/src/lexer.jl
+++ b/src/lexer.jl
@@ -317,7 +317,7 @@ function peekchar(io::IOBuffer)
 end
 
 # this implementation is copied from Base
-const _CHTMP = Array(Char, 1)
+const _CHTMP = Array{Char} (1)
 
 peekchar(s::IOStream) = begin
     if ccall(:ios_peekutf8, Int32, (Ptr{Void}, Ptr{Char}), s, _CHTMP) < 0

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -1342,7 +1342,7 @@ end
 
 function to_kws(lst)
     n = length(lst)
-    kwargs = Array(Any, n)
+    kwargs = Array{Any}(n)
     for i = 1:n
         ex = lst[i]
         if isa(¬ex, Expr) && (¬ex).head === :(=) && length((¬ex).args) == 2


### PR DESCRIPTION
Fixes a few `deprecated` warnings on `master`.