### PR TITLE
Make code agnostic with respect to the package directory

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,7 +1,7 @@
 function _precompile_()
     ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
 
-    code = readstring(Pkg.dir("JuliaParser","src","parser.jl"))
+    code = readstring(joinpath(dirname(@__FILE__), "parser.jl"))
     buf = IOBuffer(code)
     ts = Lexer.TokenStream{Tokens.Token}(buf)
     while !Lexer.eof(ts); Parser.parse(ts); end


### PR DESCRIPTION
We need to run JuliaParser from a different directory than the package directory in LanguageServer.jl, and this fix enables that.