### PR TITLE
Address more 0.6 deprecations

### DIFF
--- a/bin/testshell.jl
+++ b/bin/testshell.jl
@@ -59,7 +59,7 @@ function RunShell()
     panel.hist = REPL.REPLHistoryProvider(Dict{Symbol,Any}(:debug => panel))
 
     panel.on_done = (s,buf,ok)->begin
-        line = takebuf_string(buf)
+        line = String(take!(buf))
         if !ok || strip(line) == "q"
             LineEdit.transition(s, :abort)
         end

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -1708,7 +1708,7 @@ function parse_backquote(ps::ParseState, ts::TokenStream)
         continue
     end
     return ⨳(:macrocall, Symbol("@cmd") ⤄ Lexer.nullrange(ts),
-        takebuf_string(buf) ⤄ Lexer.makerange(ts, r))
+        String(take!(buf)) ⤄ Lexer.makerange(ts, r))
 end
 
 function parse_interpolate(ps::ParseState, ts::TokenStream, start, srange)
@@ -1742,7 +1742,7 @@ function parse_interpolate(ps::ParseState, ts::TokenStream, start, srange)
 end
 
 function tostr(buf::IOBuffer, custom::Bool)
-    str = takebuf_string(buf)
+    str = String(take!(buf))
     custom && return str
     str = unescape_string(str)
     if !(@compat isvalid(String,str))
@@ -1915,7 +1915,7 @@ function _parse_atom(ps::ParseState, ts::TokenStream)
                 c = not_eof_1(ts)
                 continue
             end
-            str = unescape_string(takebuf_string(b))
+            str = unescape_string(String(take!(b)))
             if length(str) == 1
                 # one byte e.g. '\xff' maybe not valid UTF-8
                 # but we want to use the raw value as a codepoint in this case

--- a/test/LineNumbers.jl
+++ b/test/LineNumbers.jl
@@ -3,8 +3,8 @@ using JuliaParser.LineNumbers
 using Base.Test
 
 code = "f() = 1 + 2 - 3\n"
-@test SourceFile(code)[1:2] == Vector{UInt8}["f() = 1 + 2 - 3".data, "".data]
-data2 = Vector{UInt8}[copy(code.data),[]]
+@test SourceFile(code)[1:2] == Vector{UInt8}[Vector{UInt8}("f() = 1 + 2 - 3"), Vector{UInt8}("")]
+data2 = Vector{UInt8}[copy(Vector{UInt8}(code)),[]]
 LineBreaking(UInt64(1),SourceFile(code),data2)[7] = 'x'
 @test String(data2[1]) == "f() = x + 2 - 3\n"
 @test length(SourceFile("f() = 1 + 2 - 3")) == 1

--- a/test/LineNumbers.jl
+++ b/test/LineNumbers.jl
@@ -4,7 +4,7 @@ using Base.Test
 
 code = "f() = 1 + 2 - 3\n"
 @test SourceFile(code)[1:2] == Vector{UInt8}[Vector{UInt8}("f() = 1 + 2 - 3"), Vector{UInt8}("")]
-data2 = Vector{UInt8}[copy(Vector{UInt8}(code)),[]]
+data2 = Vector{UInt8}[Vector{UInt8}(code),[]]
 LineBreaking(UInt64(1),SourceFile(code),data2)[7] = 'x'
 @test String(data2[1]) == "f() = x + 2 - 3\n"
 @test length(SourceFile("f() = 1 + 2 - 3")) == 1

--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -461,7 +461,7 @@ let code = "(foo̧ + b̂ar))",
 
     io = IOBuffer()
     JuliaParser.Diagnostics.display_diagnostic(io, code, diag, filename="test")
-    res = takebuf_string(io)
+    res = String(take!(io))
     @test startswith(res, "test:1:12")
 end
 
@@ -470,6 +470,6 @@ let code = "(foo̧ + 🔨))",
     diag = do_diag_test(code)
     io = IOBuffer()
     JuliaParser.Diagnostics.display_diagnostic(io, code, diag, filename="test")
-    res = takebuf_string(io)
+    res = String(take!(io))
     @test startswith(res, "test:1:11")
 end

--- a/test/parser.jl
+++ b/test/parser.jl
@@ -417,7 +417,7 @@ facts("test function return tuple") do
             """,
             """
             # from Iterators.jl parse failure
-            function next(it::Take, state)
+            function next(it::Iterators.Take, state)
                 n, xs_state = state
                 v, xs_state = next(it.xs, xs_state)
                 return v, (n - 1, xs_state)


### PR DESCRIPTION
This, in conjunction with #68, should remove most of the deprecation warnings on 0.6. This PR should also allow the tests to pass, as it removes the cases where the `data` field of a string was being accessed directly.